### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Unit Tests
 
 # Run on every pull request


### PR DESCRIPTION
Potential fix for [https://github.com/RinoReyns/InstagramReelsCreator/security/code-scanning/2](https://github.com/RinoReyns/InstagramReelsCreator/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow to explicitly limit the permissions granted to the GITHUB_TOKEN. Since the workflow only checks out code and runs tests, it does not require write access to repository contents or other resources. The minimal required permission is `contents: read`. This block should be added at the workflow level (top-level, after the `name:` and before `jobs:`), so it applies to all jobs in the workflow. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
