### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: pre-commit
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/RinoReyns/InstagramReelsCreator/security/code-scanning/1](https://github.com/RinoReyns/InstagramReelsCreator/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the job. Since the workflow only runs pre-commit checks and does not appear to require any write access, the minimal permission of `contents: read` is sufficient. This block should be added at the top level of the workflow (just after the `name` field and before `on:`), so it applies to all jobs in the workflow. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
